### PR TITLE
Fix issue with undoable for JS targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nimcache/
 examples/*
 !examples/*.nim
+tests/*
+!tests/*.nim

--- a/redux/undoable.nim
+++ b/redux/undoable.nim
@@ -25,7 +25,9 @@ proc undoable*[S](reducer: Reducer[S]): Reducer[UndoableState[S]] =
   )
 
   result = proc (state: UndoableState[S], action: Action): UndoableState[S] =
-    if action of UndoAction:
+    if state == nil:
+      result = initialState
+    elif action of UndoAction:
       assert state.isUndoable()
       var past = state.past
       let previous = past[high(past)]
@@ -45,8 +47,6 @@ proc undoable*[S](reducer: Reducer[S]): Reducer[UndoableState[S]] =
         present: next,
         future: future
       )
-    elif state == nil:
-      result = initialState
     else:
       let present = reducer(state=state.present, action=action)
       result = UndoableState[S](

--- a/tests/undoablejstests.nim
+++ b/tests/undoablejstests.nim
@@ -1,0 +1,31 @@
+import ../redux/ [redux, undoable]
+
+when not defined(js) and not defined(Nimdoc):
+  {.error: "These tests are designed to reproduce issues when compiling for the JavaScript platform.".}
+
+type
+  StateObj = object
+    status: string
+  State = ref StateObj
+  UpdateStatusAction = ref object of Action
+    status: string
+
+proc `$`(state: UndoableState[State]): string =
+  result = state.repr()
+
+{.experimental.}
+using
+  state: State
+  action: Action
+
+proc domaction(state, action): State =
+  if state == nil:
+    return State()
+  elif action of UpdateStatusAction:
+    state.status = UpdateStatusAction(action).status
+  return state
+
+var store = newStore(undoable(domaction))
+store.subscribe(proc (state: UndoableState[State]) = echo $state)
+store.dispatch(UpdateStatusAction(status: "New status"))
+doAssert(store.getState().getPresent().status == "New status")


### PR DESCRIPTION
This fixes an issue with undoable for JS targets due to the evaluation order of the "if" statements.
The error was:
```
/opt/code/redux.nim/tests/nimcache/undoablejstests.js:805
                                if (isObj(action_27333.m_type, NTI26019)) {
                                                      ^

TypeError: Cannot read property 'm_type' of null
    at colonanonymous__27328 (/opt/code/redux.nim/tests/nimcache/undoablejstests.js:805:27)
    at newStore_28347 (/opt/code/redux.nim/tests/nimcache/undoablejstests.js:503:26)
    at Object.<anonymous> (/opt/code/redux.nim/tests/nimcache/undoablejstests.js:894:20)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:383:7)
Error: execution of an external program failed: '/usr/bin/node /opt/code/redux.nim/tests/nimcache/undoablejstests.js '
```
I have written a test to reproduce the issue, which is included.